### PR TITLE
Add lifecycle hook for 'before:offline:start'

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ class serverlessPluginConditionalFunctions {
     this.hooks = {
       'before:package:initialize': this.applyConditions.bind(this),
       'before:offline:start:init': this.applyConditions.bind(this),
+      'before:offline:start': this.applyConditions.bind(this),
     };
     this.pluginName = 'serverless-plugin-conditional-functions';
   }


### PR DESCRIPTION
Currently, the plugin will only get called when using `offline start`. serverless-offline also allows the command `offline` on its own ([link](https://github.com/dherault/serverless-offline/blob/master/src/ServerlessOffline.js#L43)). This commit adds that lifecycle hook to the plugin.